### PR TITLE
fix: use pnpm via corepack for OpenClaw builds and fix install.sh mes…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,11 +43,11 @@ echo ""
 echo "🚀 Next steps:"
 if [ "$LINK_OK" = true ]; then
   echo "   1. Run: flock init"
-  echo "   2. Start gateway: openclaw gateway start"
+  echo "   2. Start gateway: flock start"
 else
   echo "   ⚠️ Global CLI link failed. You can still run Flock directly."
   echo "   1. Run: $FLOCK_DIR/dist/cli/index.js init"
-  echo "   2. Start gateway: openclaw gateway start"
+  echo "   2. Start gateway: $FLOCK_DIR/dist/cli/index.js start"
 fi
 echo ""
 echo "   Or run directly: $FLOCK_DIR/dist/cli/index.js init"

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -41,7 +41,7 @@ RUN npm link
 RUN mkdir -p /root/.flock && \
     git clone --branch fix/wire-after-tool-call-hook --depth 1 \
       https://github.com/mconcat/openclaw.git /root/.flock/openclaw && \
-    cd /root/.flock/openclaw && npm install --no-fund --no-audit && npm run build
+    cd /root/.flock/openclaw && corepack enable && pnpm install && pnpm run build
 
 # Docker CLI + compose plugin — talks to host daemon via mounted /var/run/docker.sock
 COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker


### PR DESCRIPTION
…saging

OpenClaw declares pnpm as its packageManager, so npm install/build fails. Add ensurePnpm() helper using corepack, update cmdInit/cmdUpdate/Dockerfile to use pnpm for OpenClaw, and fix install.sh to say "flock start" instead of "openclaw gateway start".